### PR TITLE
Set commentstring

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -43,3 +43,5 @@ hi link dockerfileUrl       Identifier
 hi link bashStatement       Function
 
 let b:current_syntax = "dockerfile"
+
+set commentstring=#\ %s


### PR DESCRIPTION
By setting the commentstring, you support commenting with plugins like tComment. Now Vim won't default to `/* */` comments.
