### PR TITLE
wildcard ftdetect for Dockerfile*

### DIFF
--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -1,2 +1,2 @@
 " Dockerfile
-autocmd BufRead,BufNewFile Dockerfile set filetype=Dockerfile
+autocmd BufRead,BufNewFile Dockerfile* set filetype=Dockerfile


### PR DESCRIPTION
there are some projects that have multiple Dockerfiles and the syntax usually is Dockerfile-some-identifier
