### PR TITLE
adding Vundle installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ make install
 git clone https://github.com/ekalinin/Dockerfile.vim.git bundle/Dockerfile
 ```
 
+####OR using Vundle:
+```bash
+# near the top of your .vimrc
+Bundle "ekalinin/Dockerfile.vim"
+```
+
 License
 =======
 


### PR DESCRIPTION
Vundle install confused me because I copied the bundle/Dockerfile path from the Pathogen install. Mostly my fault for not paying attention to the repo url, but this might help future people too.
