### PR TITLE
Add *.dock as to ftdetect

### DIFF
--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -1,2 +1,3 @@
 " Dockerfile
-autocmd BufRead,BufNewFile Dockerfile* set filetype=Dockerfile
+autocmd BufRead,BufNewFile Dockerfile* setf Dockerfile
+autocmd BufRead,BufNewFile *.dock setf Dockerfile


### PR DESCRIPTION
It is possible to pass an arbitrary file to Docker instead of letting it pick the folders Dockerfile:

```
docker build -t something - < something.dock
docker build -t something_else - < something_else.dock
```

This way you can maintain several different dockerfiles on the same folder.
