### PR TITLE
Update Dockerfile.vim

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -35,7 +35,7 @@ syn region dockerfileEmail start=/</ end=/>/ contains=@
 syn match dockerfileUrl /\(http\|https\|ssh\|hg\|git\)\:\/\/[a-zA-Z0-9\/\-\.]\+/
 
 " Comments
-syn match dockerfileComment "#.*$"
+syn match dockerfileComment "^#.*$"
 
 " Highlighting
 hi link dockerfileKeywords  Keyword


### PR DESCRIPTION
Hey there,

comment highlighting is kind of broken in Dockerfiles like [this](https://github.com/dockerfile/ubuntu/blob/master/Dockerfile#L12). I just modified the comment expression to match comments only if they start at the beginning of the line.

All the best, Tim
