### PR TITLE
fix EXPOSE snipets

### DIFF
--- a/snippets/Dockerfile.snippets
+++ b/snippets/Dockerfile.snippets
@@ -11,17 +11,17 @@ snippet R
 snippet r
 	RUN ${1:command}
 snippet C
-	CMD ${1:}
+	CMD ${1:command}
 snippet c
-	CMD ${1:}
+	CMD ${1:command}
 snippet CP
 	COPY ${1:src} ${2:dest}
 snippet cp
 	COPY ${1:src} ${2:dest}
 snippet EXP
-	EXPOSE ${1:public-port} ${2:private-port}
+	EXPOSE ${1:port}
 snippet exp
-	EXPOSE ${1:public-port} ${2:private-port}
+	EXPOSE ${1:port}
 snippet E
 	ENV ${1:key} ${2:value}
 snippet e

--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -19,9 +19,9 @@ syn keyword dockerfileKeywords VOLUME USER WORKDIR ONBUILD
 " Bash statements
 setlocal iskeyword+=-
 syn keyword bashStatement chmod chown chgrp clear complete du egrep expr fgrep cd
-syn keyword bashStatement useradd adduser
+syn keyword bashStatement useradd adduser groupadd
 syn keyword bashStatement find gnufind gnugrep grep less ls echo
-syn keyword bashStatement mkdir mv rm rmdir rpm sed sleep sort strip tail touch
+syn keyword bashStatement mkdir mv cp rm rmdir rpm sed sleep sort strip tail tailf touch head
 syn keyword bashStatement aptitude apt-key apt-get add-apt-repository yum rpm pacman
 syn keyword bashStatement node npm python virtualenv ruby php composer
 "syn keyword bashStatement svn git hg bzr


### PR DESCRIPTION
Fix `EXPOSE` snipets:
According to the documentation EXPOSE support a list of ports but not the appointment of the public to the private.

Add few bash keyword:
* `groupadd`
* `cp`
* `tailf` – standard synonym for `tail -f`
* `head`