### PR TITLE
Force e-mailaddresses to be on one line

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -31,7 +31,7 @@ syn region dockerfileString start=/"/ skip=/\\"/ end=/"/
 syn region dockerfileString1 start=/'/ skip=/\\'/ end=/'/
 
 " Emails
-syn region dockerfileEmail start=/</ end=/>/ contains=@
+syn region dockerfileEmail start=/</ end=/>/ contains=@ oneline
 
 " Urls
 syn match dockerfileUrl /\(http\|https\|ssh\|hg\|git\)\:\/\/[a-zA-Z0-9\/\-\.]\+/


### PR DESCRIPTION
This fixes problems with highlighting commands that use some form of console redirection.

```
FROM centos

RUN somecommand < /tmp/somefile
RUN secondcommand > /tmp/file
```
This simple example would be highlighted wrong before.