### PR TITLE
Change quotes for vimrc vundle snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/ekalinin/Dockerfile.vim.git bundle/Dockerfile
 ####OR using Vundle:
 ```bash
 # near the top of your .vimrc
-Plugin "ekalinin/Dockerfile.vim"
+Plugin 'ekalinin/Dockerfile.vim'
 ```
 
 License


### PR DESCRIPTION
Everything after double quotes in vim is considered as comment, so vim raises an exception for this line:

```
Plugin "ekalinin/Dockerfile.vim"
```

This fix changes double quote to single ones to prevent getting `Argument required: Plugin` error.