### PR TITLE
Update link to Dockerfile reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dockerfile.vim
 ==============
 
-Vim syntax file for [Docker](http://docker.io/)'s [Dockerfile](http://docs.docker.io/en/latest/use/builder/)
+Vim syntax file for [Docker](http://docker.io/)'s [Dockerfile](http://docs.docker.com/reference/builder/)
 and snippets for [snipMate](http://www.vim.org/scripts/script.php?script_id=2540).
 
 Screenshot


### PR DESCRIPTION
The current link leads to a 404 page.