### PR TITLE
Add autoindent for line continuation

### DIFF
--- a/indent/Dockerfile.vim
+++ b/indent/Dockerfile.vim
@@ -1,0 +1,23 @@
+if exists('b:did_indent') | finish | endif
+let b:did_indent = 1
+
+
+function! DockerfileIndent(line)
+  let prev_line = getline(a:line - 1)
+  if a:line > 1 && prev_line =~ '\\\s*$'
+    let i = indent(a:line - 1)
+    if i == 0
+      let i += &l:shiftwidth
+      if &l:expandtab && prev_line =~# '^RUN\s'
+        " Overindent past RUN
+        let i = 4 + &l:shiftwidth
+      endif
+    endif
+    return i
+  endif
+
+  return -1
+endfunction
+
+
+set indentexpr=DockerfileIndent(v:lnum)


### PR DESCRIPTION
This is a suggestion to add autoindent for line continuations.  If the previous line ends with `\` it'll match the indent of the previous line, and if the previous line starts with `RUN` it'll over indent it.