### PR TITLE
Add a *.dockerfile extension

### DIFF
--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -2,3 +2,5 @@
 autocmd BufRead,BufNewFile Dockerfile set ft=Dockerfile
 autocmd BufRead,BufNewFile Dockerfile* setf Dockerfile
 autocmd BufRead,BufNewFile *.dock setf Dockerfile
+autocmd BufRead,BufNewFile *.dockerfile setf Dockerfile
+autocmd BufRead,BufNewFile *.[Dd]ockerfile setf Dockerfile


### PR DESCRIPTION
The community is still coming together on best practices for Dockerfile naming. This is a common naming practice at least within projects at Docker. For an example see docker/notary.