### PR TITLE
Remove redundant filetype definition.

### DIFF
--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -2,5 +2,4 @@
 autocmd BufRead,BufNewFile Dockerfile set ft=Dockerfile
 autocmd BufRead,BufNewFile Dockerfile* setf Dockerfile
 autocmd BufRead,BufNewFile *.dock setf Dockerfile
-autocmd BufRead,BufNewFile *.dockerfile setf Dockerfile
 autocmd BufRead,BufNewFile *.[Dd]ockerfile setf Dockerfile


### PR DESCRIPTION
Sorry about that. I realized many files use uppper case D, Dockerfile so I made a regex match for either. But didn't notice I also left the original only lower case match in. Its redundant so we should clean it up. Again sorry. 