### PR TITLE
ENV does not permit comment after value

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -13,7 +13,7 @@ endif
 
 " Keywords
 syn keyword dockerfileKeywords FROM MAINTAINER RUN CMD COPY
-syn keyword dockerfileKeywords EXPOSE ENV ADD ENTRYPOINT
+syn keyword dockerfileKeywords EXPOSE ADD ENTRYPOINT
 syn keyword dockerfileKeywords VOLUME USER WORKDIR ONBUILD
 syn keyword dockerfileKeywords LABEL ARG HEALTHCHECK SHELL
 
@@ -42,9 +42,12 @@ syn keyword dockerfileTodo contained TODO FIXME XXX
 
 " Comments
 syn region dockerfileComment start="#" end="\n" contains=dockerfileTodo
+syn region dockerfileEnvWithComment start="^\s*ENV\>" end="\n" contains=dockerfileEnv
+syn match dockerfileEnv contained /\<ENV\>/
 
 " Highlighting
 hi link dockerfileKeywords  Keyword
+hi link dockerfileEnv       Keyword
 hi link dockerfileString    String
 hi link dockerfileString1   String
 hi link dockerfileComment   Comment


### PR DESCRIPTION
In a Dockerfile, `ENV FOO bar # baz` sets `FOO` to `bar # baz`. Previously this syntax highlighter was showing the `# baz` as a comment. It now doesn't highlight anything between `ENV` and the end of the line.

I'm not well-versed in the vim syntax system, so perhaps this could be more elegant, but it seems to be an improvement. Also, I'm not sure `ENV` is the only problematic command that doesn't support comments.

Before:

![image](https://cloud.githubusercontent.com/assets/15759/19756821/f7b0ad9c-9c6a-11e6-8149-b6fd29f7886c.png)

After:

![image](https://cloud.githubusercontent.com/assets/15759/19756828/069f6da2-9c6b-11e6-8602-6b1ed952f330.png)

Demonstration of comments being unsupported and misleading in `ENV`:

```
pda@paulbook ~/envtest ❯ docker build --tag=envtest - <<END
heredoc> FROM busybox
heredoc> ENV FOO "bar" # baz
heredoc> END
Sending build context to Docker daemon 2.048 kB
Step 1 : FROM busybox
 ---> e02e811dd08f
Step 2 : ENV FOO "bar" # baz
 ---> Running in 56dbb3a214ac
 ---> 2dd36300b8bd
Removing intermediate container 56dbb3a214ac
Successfully built 2dd36300b8bd

pda@paulbook ~/envtest ❯ docker run --rm envtest env | grep FOO
FOO=bar # baz
```