### PR TITLE
Fix Docker Compose ftdetect

### DIFF
--- a/ftdetect/docker-compose.vim
+++ b/ftdetect/docker-compose.vim
@@ -1,4 +1,2 @@
 " docker-compose.yml
-autocmd BufRead,BufNewFile docker-compose.yml set ft=docker-compose
-autocmd BufRead,BufNewFile docker-compose.yml* setf docker-compose
-autocmd BufRead,BufNewFile docker-compose* setf docker-compose
+autocmd BufRead,BufNewFile docker-compose*.{yaml,yml}* set ft=docker-compose


### PR DESCRIPTION
This upgrade simplifies the Docker Compose file type detection down to
one regex. It also prevents that ftdetect from detecting itself.
Finally, it adds support for .yaml extensions and drops support for
docker-compose files without an extension, as that is madness.

I also changed all the `setf`s to `set ft` because it wasn't working in
Neovim for some reason.