### PR TITLE
Fix typo in snippet key name

### DIFF
--- a/snippets/docker-compose.snippets
+++ b/snippets/docker-compose.snippets
@@ -65,7 +65,7 @@ snippet exten
 	extends:
 		file: ${1:file}
 		service: ${2:name}
-snippet exter
+snippet extr
 	extra_hosts:
 		- ${1:host}:${2:ip}
 snippet gr


### PR DESCRIPTION
The snippet named `exter` is currently a duplicate of `external` parameter.
This fix renames snippet `exter` to 'extr' for the `extra_hosts` parameter.