### PR TITLE
stop quoted backslashes breaking highlighting

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -28,8 +28,8 @@ syn keyword bashStatement usermod bash cat a2ensite a2dissite a2enmod a2dismod a
 syn keyword bashStatement wget gzip
 
 " Strings
-syn region dockerfileString start=/"/ skip=/\\"/ end=/"/
-syn region dockerfileString1 start=/'/ skip=/\\'/ end=/'/
+syn region dockerfileString start=/"/ skip=/\\"|\\\\/ end=/"/
+syn region dockerfileString1 start=/'/ skip=/\\'|\\\\/ end=/'/
 
 " Emails
 syn region dockerfileEmail start=/</ end=/>/ contains=@ oneline


### PR DESCRIPTION
Using backslashes in a quoted string, e.g.

`CMD foo | tr -d '\\'`

would break syntax highlighting for the remainder of the Dockerfile. This PR fixes that.