### PR TITLE
Change MAINTAINER to LABEL due deprecation

### DIFF
--- a/snippets/Dockerfile.snippets
+++ b/snippets/Dockerfile.snippets
@@ -3,9 +3,9 @@ snippet F
 snippet f
 	FROM ${1:ubuntu}
 snippet M
-	MAINTAINER ${1:name}
+	LABEL maintainer="${1:name}"
 snippet m
-	MAINTAINER ${1:name}
+	LABEL maintainer="${1:name}"
 snippet R
 	RUN ${1:command}
 snippet r


### PR DESCRIPTION
MAINTAINER is deprecated https://docs.docker.com/engine/reference/builder/#maintainer-deprecated