### PR TITLE
Fix multiple syntax issue with neo/vim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,22 @@
 install:
 	@echo "Installation:"
 	@mkdir -p ~/.vim/syntax
+	@mkdir -p ~/.vim/indent
 	@mkdir -p ~/.vim/ftdetect
+	@mkdir -p ~/.vim/ftplugin
 	@mkdir -p ~/.vim/snippets
 	@echo " * Dirs     ...    success."
 	@cp ./syntax/Dockerfile.vim 		~/.vim/syntax/
 	@cp ./syntax/docker-compose.vim 		~/.vim/syntax/
+	@echo " * Ident    ...    success."
+	@cp ./indent/Dockerfile.vim 		~/.vim/indent/
 	@echo " * Syntax   ...    success."
 	@cp ./ftdetect/Dockerfile.vim 		~/.vim/ftdetect/
 	@cp ./ftdetect/docker-compose.vim 		~/.vim/ftdetect/
 	@echo " * Filetype ...    success."
+	@cp ./ftplugin/Dockerfile.vim 		~/.vim/ftplugin/
+	@cp ./ftplugin/docker-compose.vim 		~/.vim/ftplugin/
+	@echo " * Plugin   ...    success."
 	@cp ./snippets/Dockerfile.snippets 	~/.vim/snippets/
 	@cp ./snippets/docker-compose.snippets 	~/.vim/snippets/
 	@echo " * Snippets ...    success."

--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -1,3 +1,5 @@
+" vint: -ProhibitAutocmdWithNoGroup
+
 " Dockerfile
 autocmd BufRead,BufNewFile [Dd]ockerfile set ft=Dockerfile
 autocmd BufRead,BufNewFile Dockerfile* set ft=Dockerfile

--- a/ftdetect/docker-compose.vim
+++ b/ftdetect/docker-compose.vim
@@ -1,2 +1,4 @@
+" vint: -ProhibitAutocmdWithNoGroup
+
 " docker-compose.yml
 autocmd BufRead,BufNewFile docker-compose*.{yaml,yml}* set ft=yaml.docker-compose

--- a/ftplugin/Dockerfile.vim
+++ b/ftplugin/Dockerfile.vim
@@ -1,3 +1,9 @@
+" Define comment string
+setlocal commentstring=#\ %s
+
+" Enable automatic comment insertion
+setlocal formatoptions+=cro
+
 function! DockerfileReplaceInstruction(original, replacement)
     let syn = synIDtrans(synID(line("."), col(".") - 1, 0))
     if syn != hlID("Comment") && syn != hlID("Constant") && strlen(getline(".")) == 0

--- a/ftplugin/docker-compose.vim
+++ b/ftplugin/docker-compose.vim
@@ -1,0 +1,5 @@
+" Define comment string
+setlocal commentstring=#\ %s
+
+" Enable automatic comment insertion
+setlocal formatoptions+=cro

--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -57,8 +57,3 @@ hi link dockerfileTodo      Todo
 hi link bashStatement       Function
 
 let b:current_syntax = "dockerfile"
-
-set commentstring=#\ %s
-
-" Enable automatic comment insertion
-setlocal fo+=cro

--- a/syntax/docker-compose.vim
+++ b/syntax/docker-compose.vim
@@ -2,10 +2,10 @@
 " Language: Dockerfile
 " Maintainer: Eugene Kalinin
 " Latest Revision: 11 September 2013
-" Source: http://docs.docker.io/en/latest/use/builder/
+" Source: https://docs.docker.com/compose/
 
-if exists("b:current_syntax")
-  finish
+if !exists('main_syntax')
+    let main_syntax = 'yaml'
 endif
 
 " case sensitivity (fix #17)
@@ -16,7 +16,7 @@ syn keyword dockercomposeKeywords build context dockerfile args cap_add cap_drop
 syn keyword dockercomposeKeywords command cgroup_parent container_name devices depends_on
 syn keyword dockercomposeKeywords dns dns_search tmpfs entrypoint env_file environment
 syn keyword dockercomposeKeywords expose extends extends external_links extra_hosts
-syn keyword dockercomposeKeywords group_add image isolation labels links 
+syn keyword dockercomposeKeywords group_add image isolation labels links
 syn keyword dockercomposeKeywords log_opt net network_mode networks aliases
 syn keyword dockercomposeKeywords ipv4_address ipv6_address link_local_ips pid ports
 syn keyword dockercomposeKeywords security_opt stop_signal ulimits volumes volume_driver
@@ -78,8 +78,3 @@ hi link dockercomposeTodo      Todo
 hi link bashStatement       Function
 
 let b:current_syntax = "dockercompose"
-
-set commentstring=#\ %s
-
-" Enable automatic comment insertion
-setlocal fo+=cro


### PR DESCRIPTION
This patch fixes the issue of multiple filetypes,
`yaml.docker-compose`, which vim loads YAML first,
and skip this plugin's syntax because `b:current_syntax`
is already set.

Also decouple type local options to ftplugin.

Probably fixes #54