### PR TITLE
Support underscore in URLs

### DIFF
--- a/syntax/Dockerfile.vim
+++ b/syntax/Dockerfile.vim
@@ -35,7 +35,7 @@ syn region dockerfileString1 start=/'/ skip=/\\'|\\\\/ end=/'/
 syn region dockerfileEmail start=/</ end=/>/ contains=@ oneline
 
 " Urls
-syn match dockerfileUrl /\(http\|https\|ssh\|hg\|git\)\:\/\/[a-zA-Z0-9\/\-\.]\+/
+syn match dockerfileUrl /\(http\|https\|ssh\|hg\|git\)\:\/\/[a-zA-Z0-9\/\-\._]\+/
 
 " Task tags
 syn keyword dockerfileTodo contained TODO FIXME XXX


### PR DESCRIPTION
It is even better if the underscore is syntax highlighted in the URLs.

Before:
![url_before](https://user-images.githubusercontent.com/221802/64867104-ab9a9e00-d677-11e9-83af-7c0b32f7a139.png)

After:
![url_after](https://user-images.githubusercontent.com/221802/64867113-b05f5200-d677-11e9-880f-df8e6e326992.png)

This plugin has helped me a lot. Thank you for the maintenance.