### PR TITLE
Adds instructions to install Dockerfile.vim using Vim-Plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Plugin 'ekalinin/Dockerfile.vim'
 NeoBundle 'ekalinin/Dockerfile.vim'
 ```
 
+#### Or using Vim-Plug
+
+```bash
+# Inside the Vim-Plug block on your .vimrc
+Plug 'ekalinin/Dockerfile.vim'
+```
+
+
 License
 =======
 


### PR DESCRIPTION
Hi,

this Pull Request adds instruction on how to install `Dockerfile.vim` plugin
using [vim-plug](https://github.com/junegunn/vim-plug) manager. 

I personally use it and installed `Dockerfile.vim` as described in this contribution.
Using [vim-plug](https://github.com/junegunn/vim-plug), `Dockerfile.vim` worked like a charm! 

Hope this contribution finds you well and thanks for this project!