### PR TITLE
fix #74: using setfiletype to avoid override filetype

### DIFF
--- a/ftdetect/Dockerfile.vim
+++ b/ftdetect/Dockerfile.vim
@@ -2,7 +2,7 @@
 
 " Dockerfile
 autocmd BufRead,BufNewFile [Dd]ockerfile set ft=Dockerfile
-autocmd BufRead,BufNewFile [Dd]ockerfile* set ft=Dockerfile
+autocmd BufRead,BufNewFile [Dd]ockerfile* setfiletype Dockerfile
 autocmd BufRead,BufNewFile *.[Dd]ockerfile set ft=Dockerfile
 autocmd BufRead,BufNewFile *.dock set ft=Dockerfile
 autocmd BufRead,BufNewFile [Dd]ockerfile.vim set ft=vim


### PR DESCRIPTION
Using `setfiletype` instead of `set ft=`  to avoid override default filetype detection