### PR TITLE
Docker Compose ftdetect Add compose.yml

### DIFF
--- a/ftdetect/docker-compose.vim
+++ b/ftdetect/docker-compose.vim
@@ -1,4 +1,6 @@
 " vint: -ProhibitAutocmdWithNoGroup
 
+" compose.yml
+autocmd BufRead,BufNewFile compose*.{yaml,yml}* set ft=yaml.docker-compose
 " docker-compose.yml
 autocmd BufRead,BufNewFile docker-compose*.{yaml,yml}* set ft=yaml.docker-compose


### PR DESCRIPTION
The preferred Docker Compose file name has changed to `compose.yml` or `compose.yaml`. This pr adds detection for those file names.

Ref: [Docker Compose docs](https://docs.docker.com/compose/compose-file/#compose-file)